### PR TITLE
build-sys: re-add symbols to compat-libs

### DIFF
--- a/rpms/systemd/sources/FB--add-back-compat-libs.patch
+++ b/rpms/systemd/sources/FB--add-back-compat-libs.patch
@@ -48,7 +48,7 @@ index 0c27f81..40138b2 100644
  # Dirs of external packages
  dbuspolicydir=@dbuspolicydir@
  dbussessionservicedir=@dbussessionservicedir@
-@@ -5999,6 +6017,127 @@ EXTRA_DIST += \
+@@ -5999,6 +6017,131 @@ EXTRA_DIST += \
  	test/loopy.service.d/compat.conf
  
  # ------------------------------------------------------------------------------
@@ -79,8 +79,9 @@ index 0c27f81..40138b2 100644
 +	-Wl,--version-script=$(top_srcdir)/src/compat-libs/libsystemd-journal.sym
 +
 +libsystemd_journal_la_LIBADD = \
-+	$(libsystemd_internal_la_LIBADD) \
-+	$(libsystemd_journal_internal_la_LIBADD)
++	libsystemd-journal-internal.la \
++	libsystemd-internal.la \
++	libbasic.la
 +
 +nodist_libsystemd_login_la_SOURCES = \
 +	libsystemd-login.c
@@ -98,7 +99,8 @@ index 0c27f81..40138b2 100644
 +	-Wl,--version-script=$(top_srcdir)/src/compat-libs/libsystemd-login.sym
 +
 +libsystemd_login_la_LIBADD = \
-+	 $(libsystemd_internal_la_LIBADD)
++	 libsystemd-internal.la \
++	 libbasic.la
 +
 +nodist_libsystemd_id128_la_SOURCES = \
 +	libsystemd-id128.c
@@ -116,7 +118,8 @@ index 0c27f81..40138b2 100644
 +	-Wl,--version-script=$(top_srcdir)/src/compat-libs/libsystemd-id128.sym
 +
 +libsystemd_id128_la_LIBADD = \
-+	 $(libsystemd_internal_la_LIBADD)
++	 libsystemd-internal.la \
++	 libbasic.la
 +
 +nodist_libsystemd_daemon_la_SOURCES = \
 +	libsystemd-daemon.c
@@ -134,7 +137,8 @@ index 0c27f81..40138b2 100644
 +	-Wl,--version-script=$(top_srcdir)/src/compat-libs/libsystemd-daemon.sym
 +
 +libsystemd_daemon_la_LIBADD = \
-+	 $(libsystemd_internal_la_LIBADD)
++	 libsystemd-internal.la \
++	 libbasic.la
 +
 +lib_LTLIBRARIES += \
 +	libsystemd-journal.la \


### PR DESCRIPTION
The original patch used only `$(libsystemd_journal_internal_la_LIBADD)` and `$(libsystemd_internal_la_LIBADD)`, which are only some linker flags. The real library archives have to be used.