### PR TITLE
python34-cssselect: update source url to be https

### DIFF
--- a/rpms/python34-cssselect/specfiles/python34-cssselect.spec
+++ b/rpms/python34-cssselect/specfiles/python34-cssselect.spec
@@ -8,7 +8,7 @@ Summary:        Parses CSS3 Selectors and translates them to XPath 1.0
 
 License:        BSD
 URL:            http://packages.python.org/cssselect/
-Source0:        http://pypi.python.org/packages/source/c/cssselect/cssselect-%{version}.tar.gz
+Source0:        https://pypi.python.org/packages/source/c/cssselect/cssselect-%{version}.tar.gz
 
 BuildArch:      noarch
 
@@ -18,8 +18,8 @@ BuildRequires:  python34-lxml
 %endif # if with_tests
 
 %description
-Cssselect parses CSS3 Selectors and translates them to XPath 1.0 expressions. 
-Such expressions can be used in lxml or another XPath engine to find the 
+Cssselect parses CSS3 Selectors and translates them to XPath 1.0 expressions.
+Such expressions can be used in lxml or another XPath engine to find the
 matching elements in an XML or HTML document.
 
 %prep
@@ -81,9 +81,9 @@ chmod 755 $RPM_BUILD_ROOT/%{python3_sitelib}/cssselect/tests.py
 
 * Fri Jan 17 2014 Eduardo Echeverria <echevemaster@gmail.com> 0.9.1-1
 - Update to latest upstream.
-- although this package have py3 support, the resultant python3 package 
+- although this package have py3 support, the resultant python3 package
   doesn't existed, reason? On install section, py3 setup install must be first,
-  if not, with every running of setup.py install, setup.py overwrite the files, 
+  if not, with every running of setup.py install, setup.py overwrite the files,
   this behaviour has been fixed
 - Workaround for python2 macro in epel versions
 - use python2 macro instead of python
@@ -100,9 +100,7 @@ chmod 755 $RPM_BUILD_ROOT/%{python3_sitelib}/cssselect/tests.py
 - Add tests.
 
 * Fri Nov 09 2012 Kevin Fenzi <kevin@scrye.com> 0.7.1-2
-- Fixes from review. 
+- Fixes from review.
 
 * Fri Nov 09 2012 Kevin Fenzi <kevin@scrye.com> 0.7.1-1
 - Initial version for review
-
-


### PR DESCRIPTION
Specttool failed to download sources using https url:

```
spectool -g python34-cssselect/specfiles/python34-cssselect.spec -C python34-cssselect/sources/
Getting http://pypi.python.org/packages/source/c/cssselect/cssselect-0.9.1.tar.gz to python34-cssselect/sources/cssselect-0.9.1.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 403 SSL is required
```

After updating url to https:

```
spectool -g python34-cssselect/specfiles/python34-cssselect.spec -C python34-cssselect/sources/
Getting https://pypi.python.org/packages/source/c/cssselect/cssselect-0.9.1.tar.gz to python34-cssselect/sources/cssselect-0.9.1.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0   122    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   278  100   278    0     0   1367      0 --:--:-- --:--:-- --:--:--  1367
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 32952  100 32952    0     0   131k      0 --:--:-- --:--:-- --:--:--  131k
```