### PR TITLE
python34-cssselect: disable global flag with_tests

### DIFF
--- a/rpms/python34-cssselect/specfiles/python34-cssselect.spec
+++ b/rpms/python34-cssselect/specfiles/python34-cssselect.spec
@@ -1,4 +1,4 @@
-%global with_tests 1
+# %global with_tests 1
 
 Name:           python34-cssselect
 Version:        0.9.1


### PR DESCRIPTION
Comment out global flag with_tests b/c it introduces a circular dependency.
This flag adds `python34-lxml` to the build dependencies. But `python34-lxml`
depends on `python34-cssselect` itself.