### PR TITLE
Update README and archive repository

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,28 @@
+# Where did the packages go?
+
+This repository is no longer being updated. The development of our backports
+for CentOS has moved over to the
+[Hyperscale SIG](https://wiki.centos.org/SpecialInterestGroup/Hyperscale),
+where packages that directly replace a base package (e.g. `systemd`) are still
+being actively maintained and released. Packages that are missing in CentOS
+altogether (e.g. `mkosi`) are instead being developed as part of
+[Fedora EPEL](https://fedoraproject.org/wiki/EPEL).
+
+The following table tracks where each package is currently being maintained.
+
+| Package                            | Where                                                                             |
+| ---------------------------------- | --------------------------------------------------------------------------------- |
+| dbus-broker                        | [EPEL 8](https://src.fedoraproject.org/rpms/dbus-broker/tree/epel8)               |
+| dbus                               | [CentOS Stream 8](https://git.centos.org/rpms/dbus/tree/c8s)                      |
+| dcrpm                              | [EPEL 8](https://src.fedoraproject.org/rpms/python-dcrpm/tree/epel8)              |
+| initscripts                        | [CentOS Stream 8](https://git.centos.org/rpms/initscripts/tree/c8s)               |
+| libbpf                             | [CentOS Stream 8](https://git.centos.org/rpms/libbpf/tree/c8s)                    |
+| meson                              | [Hyperscale SIG](https://git.centos.org/rpms/meson/tree/c8s-sig-hyperscale)       |
+| mkosi                              | [EPEL 8](https://src.fedoraproject.org/rpms/mkosi/tree/epel8)                     |
+| ninja-build                        | [Hyperscale SIG](https://git.centos.org/rpms/ninja-build/tree/c8s-sig-hyperscale) |
+| python3-dnf-flunk-dependent-remove | WIP                                                                               |
+| python34-cssselect                 | [EPEL 8](https://src.fedoraproject.org/rpms/python-cssselect/tree/epel8)          |
+| python34-lxml                      | [CentOS Stream 8](https://git.centos.org/rpms/python-lxml/tree/c8s)               |
+| systemd-compat-libs                | [retired](https://github.com/facebookincubator/systemd-compat-libs/pull/10)       |
+| systemd                            | [Hyperscale SIG](https://git.centos.org/rpms/systemd/tree/c8s-sig-hyperscale)     |
+| util-linux                         | [CentOS Stream 8](https://git.centos.org/rpms/util-linux/tree/c8s)                |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Facebook backported RPMs for CentOS
 
+Note: this repository is no longer being updated. See
+[MIGRATION.md](MIGRATION.md) for more information.
+
 This repo contains a number of RPM packages that we backported to CentOS 7 and 
 run in our infrastructure. Most of these packages have dependencies from EPEL 
 and from the last released CentOS 7 point release. Some packages also have 


### PR DESCRIPTION
Our backports are moving over to the [Hyperscale SIG](https://wiki.centos.org/SpecialInterestGroup/Hyperscale), so update the README accordingly.